### PR TITLE
.sexp files being mislabelled as Common Lisp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Reclassifies `.sexp` files as Scheme instead of Lisp:
+# Reclassifies `.sexp` files as Scheme instead of Common Lisp:
 *.sexp linguist-language=Scheme

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Reclassifies `.sexp` files as Scheme instead of Lisp:
+*.sexp linguist-language=Scheme


### PR DESCRIPTION
I've added a .gitattributes file to the repository , which instructs linguist to override the detection of .sexp files as Scheme instead of Common Lisp.

![image](https://user-images.githubusercontent.com/46709364/131280780-4d940899-f70b-4764-a99f-2ea5e1693eeb.png)
