### PR TITLE
Fix frame variable offsets

### DIFF
--- a/pkgs.nix
+++ b/pkgs.nix
@@ -103,8 +103,10 @@ let
 
   maybeOverrideDep = name:
     let path = ./dep + "/${name}";
-        json = builtins.fromJSON (builtins.readFile "${path}/github.json");
-        pre-src = path-src (nix-thunk.thunkSource path) // json; in
+        pre-src = path-src (nix-thunk.thunkSource path) //
+                  (if builtins.pathExists path then
+                     builtins.fromJSON (builtins.readFile "${path}/github.json")
+                  else {}); in
         overrideSrcIfShaDiff name pre-src;
 
   config = {

--- a/shell.nix
+++ b/shell.nix
@@ -22,11 +22,12 @@ in
 
       ${glow-lang.postConfigure}
       ${lib.optionalString ethereum
-        ''export GERBIL_ETHEREUM_SRC=${gerbil-ethereum.src}
-        export GERBIL_LOADPATH="$PWD:${gerbilLoadPath ([(if precompile then glow-lang else "$out")] ++ glow-lang.passthru.pre-pkg.gerbilInputs)}:$GERBIL_ETHEREUM_SRC"''}
+        ''export GERBIL_ETHEREUM_SRC="${glow-lang.passthru.pre-pkg.gerbilEthereumSrc}"''}
+      export GERBIL_LOADPATH="${glow-lang.passthru.pre-pkg.testGerbilLoadPath}"
+      PATH="${glow-lang.out}/bin:$PATH"
+      GERBIL_APPLICATION_HOME="$PWD"
+      GERBIL_APPLICATION_SOURCE="$PWD"
+      GLOW_HOME="$PWD"
+      GLOW_SRC="$PWD"
     '';
-    GERBIL_APPLICATION_HOME = "${glow-lang.src}";
-    GERBIL_APPLICATION_SOURCE = "${glow-lang.src}";
-    GLOW_HOME = "${glow-lang.src}";
-    GLOW_SRC = "${glow-lang.src}";
   }


### PR DESCRIPTION
In GitLab by @JBetz1 on Dec 29, 2020, 10:14

Computes frame variable offsets per code block rather than in a single hash table and sets brk-start based on the max frame size.