### PR TITLE
Update gerbil-ethereum: nix-thunk

### DIFF
--- a/dep/gerbil-ethereum/github.json
+++ b/dep/gerbil-ethereum/github.json
@@ -3,6 +3,6 @@
   "repo": "gerbil-ethereum",
   "branch": "master",
   "private": false,
-  "rev": "2c68dac6642bf6f527bd2b7ac2036e04d42fdc96",
-  "sha256": "1l0lym993krh4rq2cikbl5fv7b05avirf0h2k3qk2c5kypdb0k3y"
+  "rev": "bb6dc2c6390cb12078edbaf762519ff938ac4579",
+  "sha256": "0x9fbgm7pwrqdnn68sa2xynb1gfahzi1c6hqbmhgnbyh9dw807i0"
 }


### PR DESCRIPTION
In GitLab by @kwanzknoel on Jun 21, 2021, 23:20

