### PR TITLE
Run ci workflows on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: default
 
-on: push
+on: [push, pull_request]
 
 defaults:
   run:
@@ -18,7 +18,8 @@ jobs:
         uses: actions/checkout@v2
       - run: ./scripts/ci.ss before-build
       - run: ./scripts/ci.ss build
-      - env:
+      - if: ${{ github.event_name == 'push' }}
+        env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: ./scripts/ci.ss after-build
 


### PR DESCRIPTION
NOTE: First-time contributors will still require approval to run workflows.