### PR TITLE
Pass timeout argument to &define-check-participant-or-timeout

### DIFF
--- a/all-glow.ss
+++ b/all-glow.ss
@@ -22,7 +22,7 @@
   :std/net/request :std/net/websocket
   :std/pregexp :std/sort
   :std/srfi/1 :std/srfi/13 (except-in :std/srfi/19 time) ;; :std/srfi/43
-  :std/sugar :std/text/csv :std/text/hex :std/text/json :std/test
+  :std/sugar :std/assert :std/text/csv :std/text/hex :std/text/json :std/test
 
   ;; swank
   ;; NB: until https://github.com/ecraven/r7rs-swank/pull/10 is merged,

--- a/all-glow.ss
+++ b/all-glow.ss
@@ -14,7 +14,7 @@
   :gerbil/expander <expander-runtime> :std/interactive
   :gerbil/gambit/bytes :gerbil/gambit/exact :gerbil/gambit/threads :gerbil/gambit/ports
   :scheme/base-impl :scheme/char
-  :std/actor :std/coroutine
+  :std/actor :std/assert :std/coroutine
   :std/debug/heap :std/debug/memleak :std/debug/threads
   :std/error :std/format :std/getopt :std/iter :std/logger
   :std/misc/bytes :std/misc/deque :std/misc/hash :std/misc/list :std/misc/number
@@ -22,7 +22,9 @@
   :std/net/request :std/net/websocket
   :std/pregexp :std/sort
   :std/srfi/1 :std/srfi/13 (except-in :std/srfi/19 time) ;; :std/srfi/43
-  :std/sugar :std/assert :std/text/csv :std/text/hex :std/text/json :std/test
+  :std/sugar
+  :std/text/csv :std/text/hex :std/text/json
+  :std/test
 
   ;; swank
   ;; NB: until https://github.com/ecraven/r7rs-swank/pull/10 is merged,

--- a/compiler/anf/anf.ss
+++ b/compiler/anf/anf.ss
@@ -1,6 +1,6 @@
 (export #t)
 
-(import :std/iter :std/misc/hash :std/srfi/1 :std/sugar :std/assert
+(import :std/assert :std/iter :std/misc/hash :std/srfi/1 :std/sugar
         <expander-runtime>
         (for-template :mukn/glow/compiler/syntax-context)
         :mukn/glow/compiler/syntax-context

--- a/compiler/anf/anf.ss
+++ b/compiler/anf/anf.ss
@@ -1,6 +1,6 @@
 (export #t)
 
-(import :std/iter :std/misc/hash :std/srfi/1 :std/sugar
+(import :std/iter :std/misc/hash :std/srfi/1 :std/sugar :std/assert
         <expander-runtime>
         (for-template :mukn/glow/compiler/syntax-context)
         :mukn/glow/compiler/syntax-context

--- a/compiler/project/runtime-2.ss
+++ b/compiler/project/runtime-2.ss
@@ -1,7 +1,8 @@
 (export #t
         (import:
-          :std/sugar :std/assert
+          :std/assert
           :std/misc/channel
+          :std/sugar
           :gerbil/gambit/threads
           :clan/base
           :clan/poo/object
@@ -13,13 +14,14 @@
           :mukn/ethereum/ethereum
           :mukn/ethereum/known-addresses))
 
-(import :std/sugar :std/assert
+(import :std/assert
         :std/format
         :std/iter
-        :std/text/json
         :std/misc/list
         :std/misc/number
         :std/misc/channel
+        :std/sugar
+        :std/text/json
         :gerbil/gambit/threads
         (only-in :gerbil/gambit/ports output-port-readtable output-port-readtable-set! read-u8)
         (only-in :gerbil/gambit/readtables readtable-sharing-allowed?-set)

--- a/compiler/project/runtime-2.ss
+++ b/compiler/project/runtime-2.ss
@@ -1,6 +1,6 @@
 (export #t
         (import:
-          :std/sugar
+          :std/sugar :std/assert
           :std/misc/channel
           :gerbil/gambit/threads
           :clan/base
@@ -13,7 +13,7 @@
           :mukn/ethereum/ethereum
           :mukn/ethereum/known-addresses))
 
-(import :std/sugar
+(import :std/sugar :std/assert
         :std/format
         :std/iter
         :std/text/json

--- a/compiler/syntax-context.ss
+++ b/compiler/syntax-context.ss
@@ -5,7 +5,7 @@
 (import
   (rename-in :gerbil/core (lambda λ))
   :gerbil/core
-  :std/sugar
+  :std/sugar :std/assert
   ;;:clan/base
   :mukn/glow/runtime/context
   )

--- a/compiler/syntax-context.ss
+++ b/compiler/syntax-context.ss
@@ -5,7 +5,7 @@
 (import
   (rename-in :gerbil/core (lambda λ))
   :gerbil/core
-  :std/sugar :std/assert
+  :std/assert :std/sugar
   ;;:clan/base
   :mukn/glow/runtime/context
   )

--- a/contacts/transactions.ss
+++ b/contacts/transactions.ss
@@ -12,7 +12,7 @@
  :std/misc/ports
  :std/misc/process
  (only-in :std/srfi/1 first)
- :std/sugar
+ :std/sugar :std/assert
  :std/text/json
  :mukn/glow/contacts/db)
 

--- a/contacts/transactions.ss
+++ b/contacts/transactions.ss
@@ -6,13 +6,14 @@
  :clan/ffi
  :gerbil/gambit/ports
  :gerbil/gambit/threads
+ :std/assert
  :std/db/dbi
  :std/format
  :std/misc/hash
  :std/misc/ports
  :std/misc/process
  (only-in :std/srfi/1 first)
- :std/sugar :std/assert
+ :std/sugar
  :std/text/json
  :mukn/glow/contacts/db)
 

--- a/dep/gerbil-crypto/github.json
+++ b/dep/gerbil-crypto/github.json
@@ -3,6 +3,6 @@
   "repo": "gerbil-crypto",
   "branch": "master",
   "private": false,
-  "rev": "4c7c4a852b1a13af91ba2b7435218cd9dd8b8b6e",
-  "sha256": "1k4bidi4anqwg0l58qzyqzgcwynhbas2s592fm7pga4akisbqzlz"
+  "rev": "1559606fdc787f4140c3008b2f59743e3e8166c6",
+  "sha256": "145dwysmjrfdl35m4k7dyckj1vlc5923nsn6a35lsr9d6qr0ba69"
 }

--- a/dep/gerbil-ethereum/github.json
+++ b/dep/gerbil-ethereum/github.json
@@ -3,6 +3,6 @@
   "repo": "gerbil-ethereum",
   "branch": "master",
   "private": false,
-  "rev": "b88eb82168628d86acc0c95ea2fa7557bb832114",
-  "sha256": "0x75hr7ngys903028jhh7f3k4l3f77ywzlj9mymjp1j8zx6mhbhn"
+  "rev": "68a1c6a313184619c7074589575455d1dc2c0e29",
+  "sha256": "14pzwl101z6yvg92f5f268sc1cy48jmfrnvh938qpf72v874kpij"
 }

--- a/dep/gerbil-persist/github.json
+++ b/dep/gerbil-persist/github.json
@@ -3,6 +3,6 @@
   "repo": "gerbil-persist",
   "branch": "master",
   "private": false,
-  "rev": "75d4c45b77faebf0e15a63fca0e1debf21cff3eb",
-  "sha256": "0brjphzlwbyp6i4pn438xdmvima0b602w8wm9712ir1kx2ijamaa"
+  "rev": "e9b7fe9afddbee64017f132ed38f59bb01f9d3f6",
+  "sha256": "0sd1ayj1162f4d5xarfh6jspv2qz0fr60lf9wih3vvr01sirj766"
 }

--- a/dep/gerbil-poo/github.json
+++ b/dep/gerbil-poo/github.json
@@ -3,6 +3,6 @@
   "repo": "gerbil-poo",
   "branch": "master",
   "private": false,
-  "rev": "a78611418780c7477ab6937f1d6b761350913a12",
-  "sha256": "14sfvn66jbgp6ffnryja5kjra8mv1i7gr1b72fdzgrzfw099qmfr"
+  "rev": "7fa3ea0d03c8758df9881b68cf2a136b0bf035ac",
+  "sha256": "0j2wpv4pn6fhyi626s0zgi2vf7mi3rhls62fcz0i8kkr34pvkcgi"
 }

--- a/dep/gerbil-utils/github.json
+++ b/dep/gerbil-utils/github.json
@@ -3,6 +3,6 @@
   "repo": "gerbil-utils",
   "branch": "master",
   "private": false,
-  "rev": "124e025e5b3105fe6bb42cfd9f66e7eb90ea84b2",
-  "sha256": "0r6ybzi9rnr4la26xkjj25liymb5p1q0fxjw0p9xbsc9kpvynqvb"
+  "rev": "52d2b3e84604230ed8f8dd075ffc569e2841eeed",
+  "sha256": "0ry28mvzzlh70vwgj6dg4l5pga0l3r74yk96qw39ldigbn17sjwr"
 }

--- a/dep/nixpkgs/github.json
+++ b/dep/nixpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "nixpkgs",
   "branch": "devel",
   "private": false,
-  "rev": "d5afcae24454a814fb2ffcad0afdd29e4791a30e",
-  "sha256": "080lc3d4w329ldb5rggayk35q8nm6dwmcflzvi5nj8qs7c82gk3h"
+  "rev": "3a5956285b15d3cb75512892a64eaebcebfe16f8",
+  "sha256": "1yjijg775bynhccbx892sa0saxpicp1p0sg49k6fcf7ixfxvj1xz"
 }

--- a/runtime/consensus-code-generator.ss
+++ b/runtime/consensus-code-generator.ss
@@ -2,11 +2,10 @@
 
 (import
   :std/iter :std/sort :std/sugar :std/srfi/1 :std/misc/hash :std/misc/list :std/misc/number
-  :clan/base :clan/number :clan/syntax :clan/debug
+  :clan/base :clan/number :clan/syntax
   :clan/poo/io :clan/poo/object :clan/poo/brace :clan/poo/debug
   :mukn/ethereum/ethereum :mukn/ethereum/assembly :mukn/ethereum/evm-runtime
   :mukn/ethereum/assets :mukn/ethereum/types
-  :mukn/ethereum/network-config
   (only-in :mukn/glow/compiler/common hash-kref)
   ./program)
 
@@ -22,7 +21,8 @@
 
       ; TODO: rename params-end; its actual meaning is all statically-allocated
       ; space in the executable, incl. globals, so the name should reflect that.
-      params-end: [(OrFalse Nat)])
+      params-end: [(OrFalse Nat)]
+      timeout: [Nat])
     {.make:
       (lambda (some-program some-name some-timeout assets)
         {program: some-program
@@ -67,8 +67,7 @@
                 (&simple-contract-prelude)
                 &define-tail-call
                 (&define-commit-contract-call/simple self)
-                ;; TODO: pass in timeoutInBlocks option?
-                (&define-check-participant-or-timeout assets-and-vars)
+                (&define-check-participant-or-timeout assets-and-vars timeout: (.@ self timeout))
                 (&define-end-contract assets-and-vars)
                 compiled-small-functions
                 compiled-medium-functions
@@ -249,8 +248,7 @@
     (['set-participant new-participant]
       ;; TODO: support more than two participants
       (let (other-participant (find-other-participant self new-participant))
-        ;; TODO: pass in timeoutInBlocks option?
-        (DBG ccg252: (.@ self timeout) (ethereum-timeout-in-blocks))
+        ;; timeout argument is passed into `&define-check-participant-or-timeout`, not here
         [(&check-participant-or-timeout!
           must-act: (lookup-variable-offset self function-name new-participant)
           or-end-in-favor-of: (lookup-variable-offset self function-name other-participant))]))

--- a/runtime/consensus-code-generator.ss
+++ b/runtime/consensus-code-generator.ss
@@ -1,7 +1,11 @@
 (export #t)
 
 (import
-  :std/iter :std/sort :std/sugar :std/assert :std/srfi/1 :std/misc/hash :std/misc/list :std/misc/number
+  :std/assert :std/iter
+  :std/misc/hash :std/misc/list :std/misc/number
+  :std/sort
+  :std/srfi/1
+  :std/sugar
   :clan/base :clan/number :clan/syntax
   :clan/poo/io :clan/poo/object :clan/poo/brace :clan/poo/debug
   :mukn/ethereum/ethereum :mukn/ethereum/assembly :mukn/ethereum/evm-runtime

--- a/runtime/consensus-code-generator.ss
+++ b/runtime/consensus-code-generator.ss
@@ -2,10 +2,11 @@
 
 (import
   :std/iter :std/sort :std/sugar :std/srfi/1 :std/misc/hash :std/misc/list :std/misc/number
-  :clan/base :clan/number :clan/syntax
+  :clan/base :clan/number :clan/syntax :clan/debug
   :clan/poo/io :clan/poo/object :clan/poo/brace :clan/poo/debug
   :mukn/ethereum/ethereum :mukn/ethereum/assembly :mukn/ethereum/evm-runtime
   :mukn/ethereum/assets :mukn/ethereum/types
+  :mukn/ethereum/network-config
   (only-in :mukn/glow/compiler/common hash-kref)
   ./program)
 
@@ -66,6 +67,7 @@
                 (&simple-contract-prelude)
                 &define-tail-call
                 (&define-commit-contract-call/simple self)
+                ;; TODO: pass in timeoutInBlocks option?
                 (&define-check-participant-or-timeout assets-and-vars)
                 (&define-end-contract assets-and-vars)
                 compiled-small-functions
@@ -247,6 +249,8 @@
     (['set-participant new-participant]
       ;; TODO: support more than two participants
       (let (other-participant (find-other-participant self new-participant))
+        ;; TODO: pass in timeoutInBlocks option?
+        (DBG ccg252: (.@ self timeout) (ethereum-timeout-in-blocks))
         [(&check-participant-or-timeout!
           must-act: (lookup-variable-offset self function-name new-participant)
           or-end-in-favor-of: (lookup-variable-offset self function-name other-participant))]))

--- a/runtime/consensus-code-generator.ss
+++ b/runtime/consensus-code-generator.ss
@@ -1,7 +1,7 @@
 (export #t)
 
 (import
-  :std/iter :std/sort :std/sugar :std/srfi/1 :std/misc/hash :std/misc/list :std/misc/number
+  :std/iter :std/sort :std/sugar :std/assert :std/srfi/1 :std/misc/hash :std/misc/list :std/misc/number
   :clan/base :clan/number :clan/syntax
   :clan/poo/io :clan/poo/object :clan/poo/brace :clan/poo/debug
   :mukn/ethereum/ethereum :mukn/ethereum/assembly :mukn/ethereum/evm-runtime

--- a/runtime/context.ss
+++ b/runtime/context.ss
@@ -7,7 +7,7 @@
 (import
   (rename-in :gerbil/core (lambda λ))
   :gerbil/core
-  :std/sugar
+  :std/sugar :std/assert
   :clan/crypto/secp256k1
   ;;:clan/base
   )

--- a/runtime/context.ss
+++ b/runtime/context.ss
@@ -7,7 +7,7 @@
 (import
   (rename-in :gerbil/core (lambda λ))
   :gerbil/core
-  :std/sugar :std/assert
+  :std/assert :std/sugar
   :clan/crypto/secp256k1
   ;;:clan/base
   )

--- a/runtime/glow-path.ss
+++ b/runtime/glow-path.ss
@@ -2,7 +2,7 @@
 
 (import
   :std/getopt :std/iter :std/misc/hash :std/misc/string :std/sort :std/misc/string :std/srfi/13
-  :std/sugar :clan/cli :clan/config :clan/filesystem :clan/hash :clan/multicall
+  :std/sugar :std/assert :clan/cli :clan/config :clan/filesystem :clan/hash :clan/multicall
   :clan/config :clan/path :clan/path-config :clan/string
   :clan/poo/cli)
 

--- a/runtime/glow-path.ss
+++ b/runtime/glow-path.ss
@@ -1,8 +1,12 @@
 (export #t)
 
 (import
-  :std/getopt :std/iter :std/misc/hash :std/misc/string :std/sort :std/misc/string :std/srfi/13
-  :std/sugar :std/assert :clan/cli :clan/config :clan/filesystem :clan/hash :clan/multicall
+  :std/assert :std/getopt :std/iter
+  :std/misc/hash :std/misc/string
+  :std/sort
+  :std/srfi/13
+  :std/sugar
+  :clan/cli :clan/config :clan/filesystem :clan/hash :clan/multicall
   :clan/config :clan/path :clan/path-config :clan/string
   :clan/poo/cli)
 

--- a/runtime/participant-runtime.ss
+++ b/runtime/participant-runtime.ss
@@ -235,6 +235,7 @@
       (set! (.@ self first-unprocessed-event-in-block) next-event)
       (return log))
     (def from-block first-unprocessed-block)
+    ;; TODO: press X to doubt
     (def to-block (+ timer-start (.@ self agreement options timeoutInBlocks)))
     (watch-contract callback contract-address from-block to-block first-unprocessed-event-in-block))
   )
@@ -254,7 +255,9 @@
           address
           (call-with-output-u8vector
             (lambda (out)
-              (publish-frame-data self out)))))
+              (publish-frame-data self out)))
+          ;; TODO: Remove when done debugging the short-timeout bug
+          gas: 1000000))
       #f)
     (let ()
       (def log-data (.@ new-log-object data))

--- a/runtime/participant-runtime.ss
+++ b/runtime/participant-runtime.ss
@@ -7,7 +7,7 @@
   :std/pregexp :std/srfi/13 :std/misc/uuid
   :std/text/base64
   :std/crypto
-  :std/format :std/iter :std/misc/hash :std/sugar :std/misc/number :std/misc/list
+  :std/format :std/iter :std/misc/hash :std/sugar :std/assert :std/misc/number :std/misc/list
   :std/sort :std/srfi/1 :std/text/json :std/os/pid
   (for-syntax :std/stxutil)
   :gerbil/gambit/exceptions

--- a/runtime/participant-runtime.ss
+++ b/runtime/participant-runtime.ss
@@ -235,7 +235,6 @@
       (set! (.@ self first-unprocessed-event-in-block) next-event)
       (return log))
     (def from-block first-unprocessed-block)
-    ;; TODO: press X to doubt
     (def to-block (+ timer-start (.@ self agreement options timeoutInBlocks)))
     (watch-contract callback contract-address from-block to-block first-unprocessed-event-in-block))
   )
@@ -255,9 +254,7 @@
           address
           (call-with-output-u8vector
             (lambda (out)
-              (publish-frame-data self out)))
-          ;; TODO: Remove when done debugging the short-timeout bug
-          gas: 1000000))
+              (publish-frame-data self out)))))
       #f)
     (let ()
       (def log-data (.@ new-log-object data))

--- a/runtime/participant-runtime.ss
+++ b/runtime/participant-runtime.ss
@@ -4,11 +4,14 @@
   :clan/debug
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/threads :gerbil/gambit/ports :std/net/bio
   :gerbil/gambit
-  :std/pregexp :std/srfi/13 :std/misc/uuid
-  :std/text/base64
-  :std/crypto
-  :std/format :std/iter :std/misc/hash :std/sugar :std/assert :std/misc/number :std/misc/list
-  :std/sort :std/srfi/1 :std/text/json :std/os/pid
+  :std/assert :std/crypto :std/format :std/iter
+  :std/misc/hash :std/misc/list :std/misc/number :std/misc/uuid
+  :std/os/pid :std/os/signal
+  :std/pregexp
+  :std/sort
+  :std/srfi/1 :std/srfi/13
+  :std/sugar
+  :std/text/base64 :std/text/json
   (for-syntax :std/stxutil)
   :gerbil/gambit/exceptions
   :clan/base :clan/exception :clan/io :clan/json :clan/number :clan/pure/dict/assq
@@ -21,7 +24,6 @@
   :mukn/ethereum/nonce-tracker
   (only-in :mukn/glow/compiler/common hash-kref)
   :vyzo/libp2p
-  :std/os/signal
   (only-in :vyzo/libp2p/client make-client)
   :vyzo/libp2p/daemon
   (only-in ../compiler/alpha-convert/env symbol-refer)

--- a/t/asset-swap-integrationtest.ss
+++ b/t/asset-swap-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/asset-swap-integrationtest.ss
+++ b/t/asset-swap-integrationtest.ss
@@ -2,7 +2,11 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/assert :std/format :std/iter
+  :std/misc/hash :std/misc/ports
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/buy-sig-integrationtest.ss
+++ b/t/buy-sig-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/hex :std/text/json
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/hex :std/text/json
   :std/misc/ports :std/misc/process
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi

--- a/t/buy-sig-integrationtest.ss
+++ b/t/buy-sig-integrationtest.ss
@@ -2,8 +2,11 @@
 
 (import
   :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/hex :std/text/json
+  :std/assert :std/format :std/iter
   :std/misc/ports :std/misc/process
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/hex :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/buy-sig-libp2p.ss
+++ b/t/buy-sig-libp2p.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/hex :std/text/json
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/hex :std/text/json
   :std/misc/ports :std/misc/process
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi

--- a/t/buy-sig-libp2p.ss
+++ b/t/buy-sig-libp2p.ss
@@ -2,8 +2,11 @@
 
 (import
   :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/hex :std/text/json
+  :std/assert :std/format :std/iter
   :std/misc/ports :std/misc/process
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/hex :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/buy-sig-short-timeout-integrationtest.ss
+++ b/t/buy-sig-short-timeout-integrationtest.ss
@@ -45,20 +45,7 @@
       (def proc-buyer #f)
       (def proc-seller #f)
 
-      ;; Original command:
-      ;; glow start-interaction --evm-network pet --max-initial-block '%10' --timeout-in-blocks 1 --glow-app buy_sig --my-identity alice --role Buyer --database alice --assets '{"DefaultToken": "PET"}' --participants '{"Buyer": "0xa11cE3d7466d87169693843785b4bAa89B1BeA94", "Seller": "0xb0bCd0F25DAa620352FDeD9824527081265447eF"}' --params '{"digest": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470", "price": 123451234512345}'
-      ;; Modified command:
       ;; glow start-interaction --evm-network pet --test --max-initial-block '%10' --timeout-in-blocks 1 --glow-app buy_sig --my-identity t/alice --role Buyer --database alice --assets '{"DefaultToken": "PET"}' --participants '{"Buyer": "0xa71CEb0990dD1f29C2a064c29392Fe66baf05aE1", "Seller": "0xb0bb1ed229f5Ed588495AC9739eD1555f5c3aabD"}' --params '{"digest": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470", "price": 123451234512345}'
-      ;; Waiting for Seller to make a move ...
-      ;; Timed out waiting for other participant; claiming escrowed funds...
-      ;; In thread primordial:
-      ;; *** ERROR IN ##dynamic-env-bind -- This object was raised: #<json-rpc-error #107 code: -32000 message: "execution reverted" data: #!void>
-      ;; 0  ##dynamic-env-bind
-      ;; 1  ##dynamic-wind
-      ;; 2  mukn/ethereum/transaction#gas-estimate
-      ;; 3  mukn/ethereum/transaction#call-function__%
-      ;; 4  mukn/glow/runtime/participant-runtime#run-passive-code-block/contract
-
 
       (try
        (set! proc-buyer

--- a/t/buy-sig-short-timeout-integrationtest.ss
+++ b/t/buy-sig-short-timeout-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/hex :std/text/json
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/hex :std/text/json
   :std/misc/ports :std/misc/process
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi

--- a/t/buy-sig-short-timeout-integrationtest.ss
+++ b/t/buy-sig-short-timeout-integrationtest.ss
@@ -2,8 +2,11 @@
 
 (import
   :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/hex :std/text/json
+  :std/assert :std/format :std/iter
   :std/misc/ports :std/misc/process
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/hex :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/buy-sig-short-timeout-integrationtest.ss
+++ b/t/buy-sig-short-timeout-integrationtest.ss
@@ -1,0 +1,103 @@
+(export #t)
+
+(import
+  :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
+  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/hex :std/text/json
+  :std/misc/ports :std/misc/process
+  :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
+  :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
+  :clan/poo/object :clan/poo/io :clan/poo/debug
+  :clan/crypto/keccak :clan/crypto/secp256k1
+  :clan/persist/content-addressing :clan/persist/db
+  :clan/versioning
+  :mukn/ethereum/types :mukn/ethereum/ethereum :mukn/ethereum/known-addresses :mukn/ethereum/json-rpc
+  :mukn/ethereum/simple-apps :mukn/ethereum/network-config :mukn/ethereum/assets
+  :mukn/ethereum/ethereum :mukn/ethereum/hex :mukn/ethereum/transaction :mukn/ethereum/types
+  :mukn/ethereum/testing
+  ../compiler/passes
+  ../compiler/multipass
+  ../compiler/syntax-context
+  ../runtime/program
+  ../runtime/participant-runtime
+  ../runtime/reify-contract-parameters
+  ./cli-integration
+  ./utils)
+
+(def (~s v) (format "~s" v))
+
+(def buy-sig-short-timeout-integrationtest
+  (test-suite "integration test for short timeouts in ethereum/buy-sig"
+    (test-case "buy sig times out successfully with a short timeout"
+      (setup-test-env)
+
+      (def buyer-address alice)
+      (def seller-address bob)
+      (def document "abcdefghijklmnopqrstuvwxyz012345")
+      (def digest (keccak256<-string document))
+      (def price one-ether-in-wei)
+
+      (def timeout (ethereum-timeout-in-blocks))
+      (def initial-timer-start (+ (eth_blockNumber) timeout))
+
+      (def buyer-balance-before (eth_getBalance alice 'latest))
+      (def seller-balance-before (eth_getBalance bob 'latest))
+
+      (def proc-buyer #f)
+      (def proc-seller #f)
+
+      ;; Original command:
+      ;; glow start-interaction --evm-network pet --max-initial-block '%10' --timeout-in-blocks 1 --glow-app buy_sig --my-identity alice --role Buyer --database alice --assets '{"DefaultToken": "PET"}' --participants '{"Buyer": "0xa11cE3d7466d87169693843785b4bAa89B1BeA94", "Seller": "0xb0bCd0F25DAa620352FDeD9824527081265447eF"}' --params '{"digest": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470", "price": 123451234512345}'
+      ;; Modified command:
+      ;; glow start-interaction --evm-network pet --test --max-initial-block '%10' --timeout-in-blocks 1 --glow-app buy_sig --my-identity t/alice --role Buyer --database alice --assets '{"DefaultToken": "PET"}' --participants '{"Buyer": "0xa71CEb0990dD1f29C2a064c29392Fe66baf05aE1", "Seller": "0xb0bb1ed229f5Ed588495AC9739eD1555f5c3aabD"}' --params '{"digest": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470", "price": 123451234512345}'
+      ;; Waiting for Seller to make a move ...
+      ;; Timed out waiting for other participant; claiming escrowed funds...
+      ;; In thread primordial:
+      ;; *** ERROR IN ##dynamic-env-bind -- This object was raised: #<json-rpc-error #107 code: -32000 message: "execution reverted" data: #!void>
+      ;; 0  ##dynamic-env-bind
+      ;; 1  ##dynamic-wind
+      ;; 2  mukn/ethereum/transaction#gas-estimate
+      ;; 3  mukn/ethereum/transaction#call-function__%
+      ;; 4  mukn/glow/runtime/participant-runtime#run-passive-code-block/contract
+
+
+      (try
+       (set! proc-buyer
+         (open-process
+          [path: "./glow"
+           arguments: ["start-interaction"
+                       "--glow-path" (source-path "dapps")
+                       "--evm-network" "pet"
+                       "--test"
+                       ;"--handshake" "nc -l 3232"
+                       "--max-initial-block" "%10"
+                       "--timeout-in-blocks" "1"
+                       "--glow-app" "buy_sig"
+                       "--my-identity" "t/alice"
+                       "--role" "Buyer"
+                       ;"--database" "alice"
+                       "--params" (string-append "{\"price\": " (number->string price) ", \"digest\": " (~s (string-append "0x" (hex-encode digest))) "}")
+
+                       ;; Similarly, specify one of the participants here. There are only two,
+                       ;; so this test doesn't excercise the logic to read this from stdin,
+                       ;; but the other integration tests do.
+                       ;;
+                       ;; N.B. this is bob's id.
+                       "--participants" "{\"Seller\": \"0xb0bb1ed229f5Ed588495AC9739eD1555f5c3aabD\"}"
+                       "--assets" "{\"DefaultToken\": \"PET\"}"
+                       ]]))
+
+       (def buyer-output
+         (with-io-port proc-buyer (cut read-line (current-input-port) #f)))
+
+       (def buyer-balance-after (eth_getBalance alice 'latest))
+
+       (def gas-allowance (wei<-ether .01))
+
+       ;(displayln "--- buyer-output ---")
+       ;(displayln buyer-output)
+
+       (assert! (<= 0 (- buyer-balance-before buyer-balance-after) gas-allowance))
+
+       (finally
+        (ignore-errors (close-port proc-buyer))
+        (ignore-errors (kill (process-pid proc-buyer))))))))

--- a/t/coin-flip-integrationtest.ss
+++ b/t/coin-flip-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/coin-flip-integrationtest.ss
+++ b/t/coin-flip-integrationtest.ss
@@ -2,7 +2,11 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/assert :std/format :std/iter
+  :std/misc/hash :std/misc/ports
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/escrow-timeout-integrationtest.ss
+++ b/t/escrow-timeout-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/escrow-timeout-integrationtest.ss
+++ b/t/escrow-timeout-integrationtest.ss
@@ -2,7 +2,11 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/assert :std/format :std/iter
+  :std/misc/hash :std/misc/ports
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/rps-simple-integrationtest.ss
+++ b/t/rps-simple-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/rps-simple-integrationtest.ss
+++ b/t/rps-simple-integrationtest.ss
@@ -2,7 +2,11 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/assert :std/format :std/iter
+  :std/misc/hash :std/misc/ports
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/transfer-integrationtest.ss
+++ b/t/transfer-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug

--- a/t/transfer-integrationtest.ss
+++ b/t/transfer-integrationtest.ss
@@ -2,7 +2,11 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/os :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/srfi/1 :std/test :std/sugar :std/assert :std/iter :std/text/json :std/misc/ports :std/misc/hash
+  :std/assert :std/format :std/iter
+  :std/misc/hash :std/misc/ports
+  :std/srfi/1
+  :std/sugar :std/test
+  :std/text/json
   :clan/base :clan/concurrency :clan/debug :clan/decimal :clan/exception
   :clan/io :clan/json :clan/path-config :clan/ports :clan/ffi
   :clan/poo/object :clan/poo/io :clan/poo/debug


### PR DESCRIPTION
The `glow` portion of a fix towards https://github.com/Glow-Lang/glow/issues/413, which passes the `timeout:` keyword argument to `&define-check-participant-or-timeout` and adds a new integration test to make sure the first active participant times out properly when the other participant doesn't do anything.

This PR goes with https://github.com/fare/gerbil-ethereum/pull/55