### PR TITLE
changed the tag for --dest-address from -D which conflicted to -d

### DIFF
--- a/cli/interaction.ss
+++ b/cli/interaction.ss
@@ -272,7 +272,7 @@
              ;; FIXME: This should be stored and extracted from `contacts`.
              ;; It is supplied here as a temporary workaround,
              ;; until storing peerIds in `contacts` is supported.
-             (option 'dest-address "-D" "--dest-address" default: #f
+             (option 'dest-address "-d" "--dest-address" default: #f
                      help: "dest-address (only required if using libp2p as off-chain-channel)")
              (flag 'wait-for-agreement "-W" "--wait-for-agreement"
                    help: "wait for agreement via off-chain-channel")]


### PR DESCRIPTION
If you ran
```
./glow start-interaction -O $b_addr -C libp2p -E pet -D $dest -D alice

```
There might be some confusion because -D here stands for --database and --dest-address. To get rid of this confusion I changed --dest-address to be abbreviated as -d.