### PR TITLE
added notion issue-syncing workflow

### DIFF
--- a/.github/workflows/issues-notion-sync.yml
+++ b/.github/workflows/issues-notion-sync.yml
@@ -1,0 +1,29 @@
+name: Notion Sync
+
+on:
+  workflow_dispatch:
+  issues:
+    types:
+      [
+        opened,
+        edited,
+        labeled,
+        unlabeled,
+        assigned,
+        unassigned,
+        milestoned,
+        demilestoned,
+        reopened,
+        closed,
+      ]
+
+jobs:
+  notion_job:
+    runs-on: ubuntu-latest
+    name: Add GitHub Issues to Notion
+    steps:
+      - name: Add GitHub Issues to Notion
+        uses: instantish/notion-github-action@v1.2.0
+        with:
+          notion-token: ${{ secrets.NOTION_TOKEN }}
+          notion-db: ${{ secrets.NOTION_DATABASE }}


### PR DESCRIPTION
Following  [this tutorial](https://github.com/marketplace/actions/notion-x-github-action) to make a github action to automatically sync github issues to a Notion Database