### PR TITLE
Take a stab at fixing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 defaults:
   run:
-    shell: bash
+    shell: /bin/sh
 
 jobs:
   build_job:
@@ -12,7 +12,7 @@ jobs:
     container: mukn/glow:devel
     defaults:
       run:
-        shell: bash
+        shell: /bin/sh
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The docker image does not actually contain bash, which is the source of
the error we're seeing checkout. So an obvious thing to try is to use
the shell that *is* there, which is what this patch does. *crosses
fingers*