### PR TITLE
Merge the Build and Test Jobs 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 jobs:
-  build_job:
+  buildtest_job:
     runs-on: ubuntu-latest
     container: mukn/glow:devel
     defaults:
@@ -22,14 +22,6 @@ jobs:
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
         run: ./scripts/ci.ss after-build
-
-  test_job:
-    runs-on: ubuntu-latest
-    container: mukn/glow:devel
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v1
       - run: ./scripts/ci.ss before-test
       - run: ./scripts/ci.ss test
       - run: ./scripts/ci.ss after-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 jobs:
-  buildtest_job:
+  build_test_job:
     runs-on: ubuntu-latest
     container: mukn/glow:devel
     defaults:


### PR DESCRIPTION
Per conversation with Fare, this combines the build and test jobs into one in order to prevent building twice. 

This is effectively the same as before, just with the building and testing in the same job